### PR TITLE
fix windows build

### DIFF
--- a/recipes/libavrocpp/all/conandata.yml
+++ b/recipes/libavrocpp/all/conandata.yml
@@ -1,8 +1,14 @@
 sources:
-  1.10.1:
+  "1.10.1":
     url: "https://github.com/apache/avro/archive/release-1.10.1.tar.gz"
     sha256: "8fd1f850ce37e60835e6d8335c0027a959aaa316773da8a9660f7d33a66ac142"
 patches:
   "1.10.1":
     - base_path: "source_subfolder"
       patch_file: "patches/0001-add-iterator-include.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/0002-disable-tests.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/0003-allow-static-boost-linkage.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/0004-fix-windows-shared-installation.patch"

--- a/recipes/libavrocpp/all/conanfile.py
+++ b/recipes/libavrocpp/all/conanfile.py
@@ -2,7 +2,6 @@ import os
 
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
-from conans.tools import Version
 
 
 class LibavrocppConan(ConanFile):
@@ -12,15 +11,13 @@ class LibavrocppConan(ConanFile):
     description = "Avro is a data serialization system."
     homepage = "https://avro.apache.org/"
     topics = ("serialization", "deserialization")
-    settings = "os", "compiler", "build_type", "arch"
-    options = {
-        "shared": [True, False],
-        "fPIC": [True, False],
-        "with_snappy": [True, False],
-    }
     exports_sources = ["patches/*.patch"]
-    default_options = {"shared": False, "fPIC": True, "with_snappy": True}
     generators = "cmake", "cmake_find_package"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+
+    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -30,22 +27,9 @@ class LibavrocppConan(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
-    _cmake = None
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-
-    def _configure_cmake(self):
-
-        if self._cmake:
-            return self._cmake
-
-        self._cmake = CMake(self)
-        if not self.options.shared:
-            self._cmake.definitions["AVRO_DYN_LINK"] = ""
-        self._cmake.configure(source_folder=self._source_subfolder)
-        return self._cmake
 
     def configure(self):
         if self.options.shared:
@@ -55,8 +39,7 @@ class LibavrocppConan(ConanFile):
 
     def requirements(self):
         self.requires("boost/1.75.0")
-        if self.options.with_snappy:
-            self.requires("snappy/1.1.8")
+        self.requires("snappy/1.1.8")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -70,14 +53,20 @@ class LibavrocppConan(ConanFile):
             "project (Avro-cpp)",
             """project (Avro-cpp)
                include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-               conan_basic_setup()""",
+               conan_basic_setup()"""
         )
-        if self.options.with_snappy:
-            tools.replace_in_file(
-                os.path.join(self._source_subfolder, "CMakeLists.txt"),
-                "find_package(Snappy)",
-                "",
-            )
+        tools.replace_in_file(
+            os.path.join(self._source_subfolder, "CMakeLists.txt"),
+            "${SNAPPY_LIBRARIES}", "${Snappy_LIBRARIES}"
+        )
+
+    def _configure_cmake(self):
+        if not self._cmake:
+            self._cmake = CMake(self)
+            # self._cmake.verbose = True
+            self._cmake.definitions["SNAPPY_ROOT_DIR"] = self.deps_cpp_info["snappy"].rootpath.replace("\\", "/")
+            self._cmake.configure(source_folder=self._source_subfolder)
+        return self._cmake
 
     def build(self):
         self._patch_sources()
@@ -94,6 +83,7 @@ class LibavrocppConan(ConanFile):
         # FIXME: avro does not install under a CMake namespace https://github.com/apache/avro/blob/351f589913b9691322966fb77fe72269a0a2ec82/lang/c%2B%2B/CMakeLists.txt#L193
         target = "avrocpp" if self.options.shared else "avrocpp_s"
         self.cpp_info.components[target].libs = [target]
-        self.cpp_info.components[target].requires = ["boost::boost"]
-        if self.options.with_snappy:
-            self.cpp_info.components[target].requires.append("snappy::snappy")
+        self.cpp_info.components[target].requires = ["boost::boost", "snappy::snappy"]
+        # self.cpp_info.components[target].defines.append("AVRO_SOURCE")
+        if self.options.shared:
+            self.cpp_info.components[target].defines.append("AVRO_DYN_LINK")

--- a/recipes/libavrocpp/all/patches/0002-disable-tests.patch
+++ b/recipes/libavrocpp/all/patches/0002-disable-tests.patch
@@ -1,0 +1,33 @@
+From e0961af7bfb69c1129a0347a8c8ccbd9608098cf Mon Sep 17 00:00:00 2001
+From: Chris Mc <prince.chrismc@gmail.com>
+Date: Tue, 2 Feb 2021 20:29:05 -0500
+Subject: [PATCH] Update CMakeLists.txt
+
+---
+ lang/c++/CMakeLists.txt | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/lang/c++/CMakeLists.txt b/lang/c++/CMakeLists.txt
+index 69feee5b11..435d680e22 100644
+--- a/lang/c++/CMakeLists.txt
++++ b/lang/c++/CMakeLists.txt
+@@ -160,10 +160,6 @@ target_link_libraries (avrogencpp avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIE
+ enable_testing()
+ 
+ macro (unittest name)
+-    add_executable (${name} test/${name}.cc)
+-    target_link_libraries (${name} avrocpp ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
+-    add_test (NAME ${name} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+-        COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${name})
+ endmacro (unittest)
+ 
+ unittest (buffertest)
+@@ -178,7 +178,7 @@ unittest (JsonTests)
+ unittest (AvrogencppTests)
+ unittest (CompilerTests)
+ 
+-add_dependencies (AvrogencppTests bigrecord_hh bigrecord_r_hh bigrecord2_hh
++add_dependencies (bigrecord_hh bigrecord_r_hh bigrecord2_hh
+     tweet_hh
+     union_array_union_hh union_map_union_hh union_conflict_hh
+     recursive_hh reuse_hh circulardep_hh tree1_hh tree2_hh crossref_hh

--- a/recipes/libavrocpp/all/patches/0003-allow-static-boost-linkage.patch
+++ b/recipes/libavrocpp/all/patches/0003-allow-static-boost-linkage.patch
@@ -1,0 +1,29 @@
+From 902717b4aa557b60d3450a1397cae728d44ebb07 Mon Sep 17 00:00:00 2001
+From: Chris Mc <prince.chrismc@gmail.com>
+Date: Tue, 2 Feb 2021 20:55:08 -0500
+Subject: [PATCH] allow static linkage to boost
+
+---
+ lang/c++/CMakeLists.txt | 9 +--------
+ 1 file changed, 1 insertion(+), 8 deletions(-)
+
+diff --git a/lang/c++/CMakeLists.txt b/lang/c++/CMakeLists.txt
+index 435d680e22..770a9e8df5 100644
+--- a/lang/c++/CMakeLists.txt
++++ b/lang/c++/CMakeLists.txt
+@@ -44,14 +44,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR})
+ 
+ if (WIN32 AND NOT CYGWIN AND NOT MSYS)
+     add_definitions (/EHa)
+-    add_definitions (
+-        -DNOMINMAX
+-        -DBOOST_REGEX_DYN_LINK
+-        -DBOOST_FILESYSTEM_DYN_LINK
+-        -DBOOST_SYSTEM_DYN_LINK
+-        -DBOOST_IOSTREAMS_DYN_LINK
+-        -DBOOST_PROGRAM_OPTIONS_DYN_LINK
+-        -DBOOST_ALL_NO_LIB)
++    add_definitions (-DNOMINMAX)
+ else()
+ # Replease c++11 with c++17 below in case C++ 17 should be used
+     add_definitions(-std=c++11 -fPIC)

--- a/recipes/libavrocpp/all/patches/0004-fix-windows-shared-installation.patch
+++ b/recipes/libavrocpp/all/patches/0004-fix-windows-shared-installation.patch
@@ -1,0 +1,31 @@
+From 2b1a4c4fe21bbb581d6f01794a465fe0cea2f167 Mon Sep 17 00:00:00 2001
+From: Chris Mc <prince.chrismc@gmail.com>
+Date: Tue, 2 Feb 2021 21:27:31 -0500
+Subject: [PATCH] fix windows shared installation
+
+---
+ lang/c++/CMakeLists.txt | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/lang/c++/CMakeLists.txt b/lang/c++/CMakeLists.txt
+index 770a9e8df5..3ed26fa27d 100644
+--- a/lang/c++/CMakeLists.txt
++++ b/lang/c++/CMakeLists.txt
+@@ -173,8 +173,6 @@ add_dependencies (AvrogencppTests bigrecord_hh bigrecord_r_hh bigrecord2_hh
+     recursive_hh reuse_hh circulardep_hh tree1_hh tree2_hh crossref_hh
+     primitivetypes_hh empty_record_hh)
+ 
+-include (InstallRequiredSystemLibraries)
+-
+ set (CPACK_PACKAGE_FILE_NAME "avrocpp-${AVRO_VERSION_MAJOR}")
+ 
+ include (CPack)
+@@ -182,7 +180,7 @@ include (CPack)
+ install (TARGETS avrocpp avrocpp_s
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib
+-    RUNTIME DESTINATION lib)
++    RUNTIME DESTINATION bin)
+ 
+ install (TARGETS avrogencpp RUNTIME DESTINATION bin)
+

--- a/recipes/libavrocpp/all/test_package/conanfile.py
+++ b/recipes/libavrocpp/all/test_package/conanfile.py
@@ -9,6 +9,7 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+        cmake.verbose = True
         cmake.definitions["AVROCPP_SHARED"] = self.options["libavrocpp"].shared
         cmake.configure()
         cmake.build()

--- a/recipes/libavrocpp/all/test_package/test_package.cpp
+++ b/recipes/libavrocpp/all/test_package/test_package.cpp
@@ -2,24 +2,43 @@
 #include "avro/Encoder.hh"
 #include "avro/Specific.hh"
 
+namespace c {
+struct cpx {
+    double re;
+    double im;
+};
+
+}
+namespace avro {
+template<> struct codec_traits<c::cpx> {
+    static void encode(Encoder& e, const c::cpx& v) {
+        avro::encode(e, v.re);
+        avro::encode(e, v.im);
+    }
+    static void decode(Decoder& d, c::cpx& v) {
+        avro::decode(d, v.re);
+        avro::decode(d, v.im);
+    }
+};
+
+}
+
 int main()
 {
-    int64_t dummy = 1234;
-    std::unique_ptr<avro::OutputStream> out = avro::memoryOutputStream();
+    std::unique_ptr<avro::OutputStream> out = avro::memoryOutputStream(128);
     avro::EncoderPtr e = avro::binaryEncoder();
     e->init(*out);
-    avro::encode(*e, dummy);
+    c::cpx c1;
+    c1.re = 1.0;
+    c1.im = 2.13;
+    avro::encode(*e, c1);
 
     std::unique_ptr<avro::InputStream> in = avro::memoryInputStream(*out);
     avro::DecoderPtr d = avro::binaryDecoder();
     d->init(*in);
 
-    int64_t decoded;
-    avro::decode(*d, decoded);
-
-    if (dummy != decoded)
-    {
-        return 1;
-    }
+    c::cpx c2{};
+    avro::decode(*d, c2);
+    std::cout << '(' << c2.re << ", " << c2.im << ')' << std::endl;
     return 0;
 }


### PR DESCRIPTION
This was a pain.

Failing currently in CCI

- They force boost shared flags (default is False in CCI)
- Th Conan generated `FindSnappy` took over and the variable casing was a problem

After that...

- Fix dll import macro for consumer
- MSVC installation put it into the `lib/` which Conan expects `bin/` by default so runtime crash

Performance/convience
- stopped build the test code (not needed for CCI)
- don't install windows runtimes